### PR TITLE
Added option to pass browser-specific options to browser.

### DIFF
--- a/trunk/wikipedia2text
+++ b/trunk/wikipedia2text
@@ -20,7 +20,7 @@ NAME
     articles. The output will be printed to standard out.
     
 SYNOPSIS
-    `basename $0` [-BCnNoOpPsSuU] [-b prog] [-c patt] [-i patt] [-l lang] query
+    `basename $0` [-BCnNoOpPsSuU] [-b prog] [-c patt] [-i patt] [-l lang] [-X browseroptions] query
     `basename $0` -o [-b prog] [-l lang] query
     `basename $0` [-h]
     `basename $0` -v|-r
@@ -32,17 +32,19 @@ SYNOPSIS
     -u	Just output the query URL	    -U	open URL in browser
     -v	display version			    -h	display help		   
 
-    -r          open Random Page
-    -i patt	colorize pattern (case insensitive)
-    -I patt	colorize pattern (case-sensitive, alias -c)
-    -b prog	use prog as browser (by default to invoke elinks, links2,
-		links, lynx or w3m, if found)
-    -l lang	use language (currently supported are: af, als, ca, cs, da, 
-		de, en, eo, es, fi, fr, hu, ia, is, it, la, lb, nds, nl, nn,
-		no, pl, pt, rm, ro, simple, sk, sl, sv, tr)
-    -W url      use url as base-URL for wikipedia (e.g. use a different 
-		Wiki, Querying this URL will happen by appending the search 
-		term.
+    -r                    open Random Page
+    -i patt               colorize pattern (case insensitive)
+    -I patt               colorize pattern (case-sensitive, alias -c)
+    -b prog               use prog as browser (by default to invoke elinks, links2,
+                          links, lynx or w3m, if found)
+    -l lang               use language (currently supported are: af, als, ca, cs, da, 
+                          de, en, eo, es, fi, fr, hu, ia, is, it, la, lb, nds, nl, nn,
+                          no, pl, pt, rm, ro, simple, sk, sl, sv, tr)
+    -W url                use url as base-URL for wikipedia (e.g. use a different 
+                          Wiki, Querying this URL will happen by appending the search 
+                          term.
+    -X "browseroptions"   pass through options to browser, e.g., "-width 180"
+                          (warnings: must be in quotes; browser specific, not checked)
 
     Query can be any term to search for at Wikipedia. Special
     characters will be taken care of. Note that only one query term is
@@ -254,23 +256,23 @@ function openurl(){
 
 function summary(){
     if [ "${COLOR}" = "true" ]; then
-	"${BROWSER}" -dump "${URL}" |grep -v copyright | head -n 22 \
-	| tail -n 17  |stripOutput | colorize
+	summaryCommand="${BROWSER} ${BROWSEROPTIONS} -dump ${URL} |grep -v copyright | head -n 22 | tail -n 17  |stripOutput | colorize"
     else
-	"${BROWSER}" -dump "${URL}" |grep -v copyright | head -n 22 \
-	| tail -n 17  | stripOutput
+	summaryCommand="${BROWSER} ${BROWSEROPTIONS} -dump ${URL} |grep -v copyright | head -n 22 | tail -n 17  | stripOutput"
     fi
+    eval ${summaryCommand}
 }
 
 function getInfo(){
     #LINES=$("${BROWSER}" -dump "${URL}" |wc -l)
     #LINES=$(expr ${LINES} - 6)
     if [ "${COLOR}" = "false" ]; then
-	#"${BROWSER}" -dump "${URL}"| tail -n ${LINES}  |stripOutput  
-	"${BROWSER}" -dump "${URL}"| stripOutput  
+	#"${BROWSER}" "${BROWSEROPTIONS}" -dump "${URL}"| tail -n ${LINES}  |stripOutput  
+	getInfoCommand="${BROWSER} ${BROWSEROPTIONS} -dump ${URL} | stripOutput"
     else
-	"${BROWSER}" -dump "${URL}"| stripOutput |colorize 
+	getInfoCommand="${BROWSER} ${BROWSEROPTIONS} -dump ${URL} | stripOutput |colorize"	
     fi
+    eval ${getInfoCommand}
 }
 
 # First read in the Run configuration File, if one is found 
@@ -280,7 +282,7 @@ if [ -r ~/.`basename $0`rc ]; then
 fi
 
 # Process commandline parameters
-while getopts "BCnNoOpPsSuvhrUl:b:c:i:B:W:" ARGS 
+while getopts "BCnNoOpPsSuvhrUl:b:c:i:B:W:X:" ARGS 
     do
 	case ${ARGS} in
 	b) ABROWSER=${OPTARG} ;;
@@ -303,6 +305,7 @@ while getopts "BCnNoOpPsSuvhrUl:b:c:i:B:W:" ARGS
 	U) OPENURL="true";;
 	v) getVersion; exit 0 ;;
 	W) WURL=${OPTARG} ;;
+	X) BROWSEROPTIONS=${OPTARG} ;;
 	h) display_help; exit 0 ;;
 	*) display_help; exit 1 ;;
 	esac
@@ -339,8 +342,6 @@ fi
 if [ "$OPENURL" = "true" ]; then
     URL="$*"
 fi
-
-
 
 # Check for Alternative Browser
 if [ -n "${ABROWSER}" -o "${BROWSER}" ]; then
@@ -402,7 +403,8 @@ fi
 
 if [ "${OUTPUTURL}" = "true" ]; then
     if [ "${COLOR}" = "false" ]; then
-	echo "${URL}" 
+	echo "${URL}"
+	echo "${BROWSER}" "${BROWSEROPTIONS}" -dump "${URL}"
     else
 	echo -e "\033[0;34m${URL}\033[0m" 
     fi


### PR DESCRIPTION
Dear Christian,
Thank you very much for wikipedia2text -- I am using it regularly for a political economy project.  

I added an option (-X) so that browser-specific options, e.g., "-width=180" in lynx, can be passed through to the browser.  There isn't checking, but the command will fail if the browser can't accept the option.  I also modified the "-u" option so that it shows both the url generated and the command generated.  I'd welcome your comments, etc. Thanks.

Best,
Michael
