### PR TITLE
More accurate summary by parsing source code

### DIFF
--- a/wikipedia2text
+++ b/wikipedia2text
@@ -218,9 +218,13 @@ function openurl(){ #{{{1
   "${BROWSER}" "${URL}"
 }
 function summary(){ #{{{1
-  summaryCommand="${BROWSER} ${BROWSEROPTIONS} -dump ${URL} |grep -v copyright | head -n 22 | tail -n 17  | stripOutput"
+  TMPFILE="/tmp/wiki-sum.html"
   if [ "${COLOR}" = "true" ]; then
-    summaryCommand="${summaryCommand} | colorize"
+    summaryCommand="curl -s -L ${URL} | grep \/table -A400 | grep -v \/table  | grep \<div -m1 -B400 | sed -e \"\$
+d\" > $TMPFILE && w3m -dump $TMPFILE | stripOutput | colorize && rm $TMPFILE"
+  else
+    summaryCommand="curl -s -L ${URL} | grep \/table -A400 | grep -v \/table  | grep \<div -m1 -B400 | sed -e \"\$
+d\" > $TMPFILE && w3m -dump $TMPFILE | stripOutput && rm $TMPFILE"
   fi
   eval ${summaryCommand}
 }


### PR DESCRIPTION
This is an alternative way to grab wikipedia summary which is more accurate and uses curl, grep and sed.

Explanation:
It grabs the source code of a Wikipedia article using curl and keeps it in a temporary file $TMPFILE, 
grep the appropriate summary lines, uses sed to remove a last unimportant line (this should probably be replaced with a less cumbersome command), 
and format-print it as usual and ${BROWSER} -dump it. 
After that it removes the temporary file.

Possible TODO: 
Add a test for the existence of curl. 
Allow wget as an alternative.
Split the last 'rm' part of the command so the previous `if` structure could be used i.e. add the colorize string after the basic command and then append the 'rm' part in each ... 
